### PR TITLE
Migrate plugin to ckeditor5 v42.0.0 new installation method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .npmignore
+/node_modules/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ If you find this plugin useful, consider supporting the author to create and mai
 
 ## Prerequisites
 
-Before you begin, ensure you have the following dependencies installed:
+For version 2.0.0 and above, the FullScreen plugin requires `ckeditor5` as a dependency.
+
+- [CKEditor 5](https://www.npmjs.com/package/ckeditor5)
+
+Install it using npm:
+
+```bash
+npm install --save ckeditor5
+```
+
+For version 1, the FullScreen plugin requires CKEditor 5 Core and CKEditor 5 UI as dependencies.
 
 - [CKEditor 5 Core](https://www.npmjs.com/package/@ckeditor/ckeditor5-core)
 - [CKEditor 5 UI](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@pikulinpw/ckeditor5-fullscreen",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Maximize your CKEditor 5 editing space with the FullScreen plugin. Offering a seamless way to expand the editor to full screen, it ensures an uninterrupted and expansive writing canvas.",
   "main": "src/FullScreen.js",
+  "types": "src/FullScreen.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -26,11 +27,6 @@
   },
   "homepage": "https://github.com/pikulinpw/ckeditor5-fullscreen#readme",
   "dependencies": {
-    "@ckeditor/ckeditor5-core": ">=27.1.0",
-    "@ckeditor/ckeditor5-ui": ">=27.1.0"
-  },
-  "peerDependencies": {
-    "@ckeditor/ckeditor5-core": ">=27.1.0",
-    "@ckeditor/ckeditor5-ui": ">=27.1.0"
+    "ckeditor5": ">=42.0.0"
   }
 }

--- a/src/FullScreen.d.ts
+++ b/src/FullScreen.d.ts
@@ -1,0 +1,17 @@
+declare module '@pikulinpw/ckeditor5-fullscreen' {
+    import { Plugin } from '@ckeditor/ckeditor5-core';
+    import { Editor, PluginConstructor } from "ckeditor5";
+
+    export class FullScreen extends Plugin {
+        init(): void;
+    }
+
+    export const pikulinpw_ckeditor5_fullscreen: {
+        getFullscreenElement(element: HTMLElement): boolean | Element;
+        requestFullscreen(element: HTMLElement): void;
+        exitFullscreen(element: HTMLElement): void;
+    };
+
+    const FullScreenPlugin: string | PluginConstructor<Editor>;
+    export default FullScreenPlugin;
+}

--- a/src/FullScreen.js
+++ b/src/FullScreen.js
@@ -1,7 +1,6 @@
 //Pikulin.PW FullScreen Plugin – https://github.com/pikulinpw/ckeditor5-fullscreen
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import { Plugin, ButtonView } from 'ckeditor5';
 
 const pikulinpw_ckeditor5_fullscreen = {
     'getFullscreenElement': (element) => {


### PR DESCRIPTION
## What?
Updated the module to the new Installation method implemented in ckeditor 5 v42.0.0,
Added typescript support 
Updated the module to v2 for breaking changes and added new instructions to the readme file

## Why?
Fixes [CKEditorError: ckeditor-duplicated-modules #16632](https://github.com/ckeditor/ckeditor5/issues/16632)
Closes [Support new installation methods #6](https://github.com/pikulinpw/ckeditor5-fullscreen/issues/6)

## Testing?
Tested manually in conjunction with ckeditor5-react and nextjs

